### PR TITLE
Fix 40 bytes crypting

### DIFF
--- a/src/mrb_sha1.c
+++ b/src/mrb_sha1.c
@@ -37,8 +37,7 @@ mrb_sha1_hex(mrb_state *mrb, mrb_value self)
     digest_hex[i*2+0] = nr2char((digest[i] >> 4) & 0xf);
     digest_hex[i*2+1] = nr2char(digest[i] & 0x0f);
   }
-  // digest_hex[40] = 0;
-
+  
   return mrb_str_new(mrb, (char*) digest_hex, 40);
 }
 

--- a/src/mrb_sha1.c
+++ b/src/mrb_sha1.c
@@ -19,7 +19,7 @@ static mrb_value
 mrb_sha1_hex(mrb_state *mrb, mrb_value self)
 {
   unsigned char digest[20];
-  unsigned char digest_hex[33];
+  unsigned char digest_hex[41];
   mrb_value arg = mrb_nil_value();
   int i;
   struct sha1_context ctx;
@@ -33,13 +33,13 @@ mrb_sha1_hex(mrb_state *mrb, mrb_value self)
   sha1_update(&ctx, (uint8*) RSTRING_PTR(arg), RSTRING_LEN(arg));
   sha1_finish(&ctx, (uint8*)&digest[0]);
 
-  for (i = 0; i < 16; i++) {
+  for (i = 0; i < 20; i++) {
     digest_hex[i*2+0] = nr2char((digest[i] >> 4) & 0xf);
     digest_hex[i*2+1] = nr2char(digest[i] & 0x0f);
   }
-  digest_hex[32] = 0;
+  // digest_hex[40] = 0;
 
-  return mrb_str_new(mrb, (char*) digest_hex, 32);
+  return mrb_str_new(mrb, (char*) digest_hex, 40);
 }
 
 /*********************************************************

--- a/test/sha1.rb
+++ b/test/sha1.rb
@@ -1,7 +1,7 @@
 assert('SHA1 Hash for "ruby"') do
-  SHA1.sha1_hex('ruby') == '18e40e1401eef67e1ae69efab09afb71'
+  SHA1.sha1_hex('ruby') == '18e40e1401eef67e1ae69efab09afb71f87ffb81'
 end
 
 assert('SHA1 Hash for old example') do
-  SHA1::sha1_hex('お前はどこのワカメじゃ') == "de0cd7ded3e47b643b882abf100a7a39"
+  SHA1::sha1_hex('お前はどこのワカメじゃ') == "de0cd7ded3e47b643b882abf100a7a3930e3e8b3"
 end


### PR DESCRIPTION
Fix the SHA1 produce 32 bytes while standard ruby Digest::SHA1 produce 40 bytes.